### PR TITLE
add basic osmlogs collector

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -41,6 +41,8 @@ func main() {
 	collectors = append(collectors, kubeletCmdCollector)
 	systemPerfCollector := collector.NewSystemPerfCollector(exporter)
 	collectors = append(collectors, systemPerfCollector)
+	osmLogsCollector := collector.NewOsmLogsCollector(exporter)
+	collectors = append(collectors, osmLogsCollector)
 
 	for _, c := range collectors {
 		waitgroup.Add(1)

--- a/deployment/aks-periscope.yaml
+++ b/deployment/aks-periscope.yaml
@@ -69,7 +69,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: aks-periscope
-        image: aksrepos.azurecr.io/staging/aks-periscope:v0.3
+        image: sanyakochh/aks-periscope:latest
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -20,6 +20,8 @@ const (
 	NetworkOutbound
 	// NodeLogs defines NodeLogs Collector Type
 	NodeLogs
+	// OsmLogs defines OsmLogs Collector Type
+	OsmLogs
 	// SystemLogs defines SystemLogs Collector Type
 	SystemLogs
 	// SystemPerf defines SystemPerf Collector Type
@@ -28,7 +30,7 @@ const (
 
 // Name returns type name
 func (t Type) name() string {
-	return [...]string{"dns", "containerlogs", "iptables", "kubeletcmd", "kubeobjects", "networkoutbound", "nodelogs", "systemlogs", "systemperf"}[t]
+	return [...]string{"dns", "containerlogs", "iptables", "kubeletcmd", "kubeobjects", "networkoutbound", "nodelogs", "osmlogs", "systemlogs", "systemperf"}[t]
 }
 
 // BaseCollector defines Base Collector

--- a/pkg/collector/osmlogs_collector.go
+++ b/pkg/collector/osmlogs_collector.go
@@ -1,0 +1,50 @@
+package collector
+
+import (
+	"path/filepath"
+
+	"github.com/Azure/aks-periscope/pkg/interfaces"
+	"github.com/Azure/aks-periscope/pkg/utils"
+)
+
+// OsmLogsCollector defines an OsmLogs Collector struct
+type OsmLogsCollector struct {
+	BaseCollector
+}
+
+var _ interfaces.Collector = &OsmLogsCollector{}
+
+// NewOsmLogsCollector is a constructor
+func NewOsmLogsCollector(exporter interfaces.Exporter) *OsmLogsCollector {
+	return &OsmLogsCollector{
+		BaseCollector: BaseCollector{
+			collectorType: OsmLogs,
+			exporter:      exporter,
+		},
+	}
+}
+
+// Collect implements the interface method
+func (collector *OsmLogsCollector) Collect() error {
+	rootPath, err := utils.CreateCollectorDir(collector.GetName())
+	if err != nil {
+		return err
+	}
+	// will want multiple files here - can define resources to query in deployment.yaml and iterate through the commands+resources needed and create multiple files
+	// see kubeobject collector for example
+	allResourcesFile := filepath.Join(rootPath, "allResources")
+
+	output, err := utils.RunCommandOnContainer("kubectl", "get", "all", "--all-namespaces", "--selector", "app.kubernetes.io/name=openservicemesh.io", "-o", "json")
+	if err != nil {
+		return err
+	}
+
+	err = utils.WriteToFile(allResourcesFile, output)
+	if err != nil {
+		return err
+	}
+
+	collector.AddToCollectorFiles(allResourcesFile)
+
+	return nil
+}


### PR DESCRIPTION
* adds osmlogs collector
* creates osmlogs dir and one log file for all resources to match: `kubectl get all --all-namespaces --selector app.kubernetes.io/name=openservicemesh.io`