### PR TITLE
add mesh list helper & query all resources

### DIFF
--- a/pkg/collector/osmlogs_collector.go
+++ b/pkg/collector/osmlogs_collector.go
@@ -30,11 +30,12 @@ func (collector *OsmLogsCollector) Collect() error {
 	if err != nil {
 		return err
 	}
-	// will want multiple files here - can define resources to query in deployment.yaml and iterate through the commands+resources needed and create multiple files
+	// can define resources to query in deployment.yaml and iterate through the commands+resources needed and create multiple files
 	// see kubeobject collector for example
-	allResourcesFile := filepath.Join(rootPath, "allResources")
 
-	output, err := utils.RunCommandOnContainer("kubectl", "get", "all", "--all-namespaces", "--selector", "app.kubernetes.io/name=openservicemesh.io", "-o", "json")
+	// Get osm resources as table
+	allResourcesFile := filepath.Join(rootPath, "allResources")
+	output, err := utils.RunCommandOnContainer("kubectl", "get", "all", "--all-namespaces", "--selector", "app.kubernetes.io/name=openservicemesh.io")
 	if err != nil {
 		return err
 	}
@@ -46,5 +47,28 @@ func (collector *OsmLogsCollector) Collect() error {
 
 	collector.AddToCollectorFiles(allResourcesFile)
 
+	// Get osm resource configs
+	allResourceConfigsFile := filepath.Join(rootPath, "allResourceConfigs")
+	output, err = utils.RunCommandOnContainer("kubectl", "get", "all", "--all-namespaces", "--selector", "app.kubernetes.io/name=openservicemesh.io", "-o", "json")
+	if err != nil {
+		return err
+	}
+
+	err = utils.WriteToFile(allResourceConfigsFile, output)
+	if err != nil {
+		return err
+	}
+
+	collector.AddToCollectorFiles(allResourceConfigsFile)
+
 	return nil
+}
+
+// Helper function to get all meshes in the cluster
+func getMeshList() (string, error) {
+	meshList, err := utils.RunCommandOnContainer("kubectl", "get", "deployments", "--all-namespaces", "-o=jsonpath=\"{..meshName}\"", "-l", "app=osm-controller")
+	if err != nil {
+		return "", err
+	}
+	return meshList, nil
 }


### PR DESCRIPTION
- Creates two log files
* allResources reflects the output of `kubectl get all --all-namespaces --selector app.kubernetes.io/name=openservicemesh.io'
* allResourceConfigs reflects the output of `kubectl get all --all-namespaces --selector app.kubernetes.io/name=openservicemesh.io -o json'
* namespaceMetadata files reflect the output of `kubectl get namespaces <namespace> -o=jsonpath={..metadata}` for every namespace in every running mesh in the cluster

- Adds helper function that returns an array of all OSMs in the cluster

[yes, I probably should've done this in separate PRs]