### PR TITLE
Absence of namespaces in a mesh should not be an error

### DIFF
--- a/pkg/collector/osmlogs_collector.go
+++ b/pkg/collector/osmlogs_collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -62,7 +63,8 @@ func (collector *OsmLogsCollector) Collect() error {
 	for _, meshName := range meshList {
 		namespacesInMesh, err := getResourceList("namespaces", "openservicemesh.io/monitored-by="+meshName, "-o=jsonpath={..name}", " ")
 		if err != nil {
-			return err
+			log.Printf("Failed to get namespaces within osm mesh '%s': %+v\n", meshName, err)
+			continue
 		}
 		osmNamespaces := append(namespacesInMesh, meshNamespacesList...)
 		if err = collectDataFromNamespaces(collector, osmNamespaces, rootPath, meshName); err != nil {


### PR DESCRIPTION
Absence of namespaces in a mesh should not be an error

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>