### PR TITLE
Add smi collector

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -43,6 +43,8 @@ func main() {
 	collectors = append(collectors, systemPerfCollector)
 	osmLogsCollector := collector.NewOsmLogsCollector(exporter)
 	collectors = append(collectors, osmLogsCollector)
+	smiLogsCollector := collector.NewSmiLogsCollector(exporter)
+	collectors = append(collectors, smiLogsCollector)
 
 	for _, c := range collectors {
 		waitgroup.Add(1)

--- a/deployment/aks-periscope.yaml
+++ b/deployment/aks-periscope.yaml
@@ -23,6 +23,12 @@ rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["access.smi-spec.io", "specs.smi-spec.io", "split.smi-spec.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/collector/smilogs_collector.go
+++ b/pkg/collector/smilogs_collector.go
@@ -1,0 +1,79 @@
+package collector
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Azure/aks-periscope/pkg/interfaces"
+	"github.com/Azure/aks-periscope/pkg/utils"
+)
+
+// SmiLogsCollector defines an SmiLogs Collector struct
+type SmiLogsCollector struct {
+	BaseCollector
+}
+
+var _ interfaces.Collector = &SmiLogsCollector{}
+
+// NewSmiLogsCollector is a constructor
+func NewSmiLogsCollector(exporter interfaces.Exporter) *SmiLogsCollector {
+	return &SmiLogsCollector{
+		BaseCollector: BaseCollector{
+			collectorType: SmiLogs,
+			exporter:      exporter,
+		},
+	}
+}
+
+// Collect implements the interface method
+func (collector *SmiLogsCollector) Collect() error {
+	smiCrdList, err := getSmiCustomResourceDefinitions()
+	if err != nil {
+		return err
+	}
+
+	rootPath, err := utils.CreateCollectorDir(collector.GetName())
+	if err != nil {
+		return err
+	}
+
+	for _, smiCrd := range smiCrdList {
+		var smiResourcesMap = map[string][]string{
+			smiCrd + "_table.tsv":    []string{"get", smiCrd, "--all-namespaces", "-o=wide"},
+			smiCrd + "_configs.json": []string{"get", smiCrd, "--all-namespaces", "-o=json"},
+		}
+
+		for fileName, kubeCmd := range smiResourcesMap {
+			if err = collector.collectKubeResourceToFile(rootPath, fileName, kubeCmd); err != nil {
+				log.Printf("Failed to collect %s for SMI: %+v", fileName, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// getSmiCustomResourceDefinitions returns SMI CRDs within the cluster
+func getSmiCustomResourceDefinitions() ([]string, error) {
+	outputStreams, err := utils.RunCommandOnContainerWithOutputStreams("kubectl", "get", "CustomResourceDefinitions", "--all-namespaces", "-o=jsonpath={..metadata.name}")
+	if err != nil {
+		return nil, err
+	}
+
+	crdList := strings.Split(strings.Trim(outputStreams.Stdout, "\""), " ")
+	// If the CRD is not found within the cluster, then log a message and do not return any resources.
+	if len(crdList) == 0 {
+		err := fmt.Errorf("No CustomResourceDefinitions resource found in the cluster.")
+		return nil, err
+	}
+
+	var smiCrdList []string
+	for _, crd := range crdList {
+		if strings.Contains(crd, "smi-spec.io") {
+			smiCrdList = append(smiCrdList, crd)
+		}
+	}
+
+	return smiCrdList, nil
+}


### PR DESCRIPTION
Add smi collector for periscope.

For each SMI resource within the cluster,
(1) write the SMI resource details as a table to a TSV file,
(2) write the SMI resource configs to a JSON file.

![image](https://user-images.githubusercontent.com/13926417/116761803-74ecd500-a9cd-11eb-86d9-76d377c9ed38.png)

![image](https://user-images.githubusercontent.com/13926417/116761812-7cac7980-a9cd-11eb-9a0c-c402d40934c3.png)
