### PR TITLE
ref: organize files into subdirs by mesh and ns

### DIFF
--- a/pkg/collector/smilogs_collector.go
+++ b/pkg/collector/smilogs_collector.go
@@ -40,7 +40,7 @@ func (collector *SmiLogsCollector) Collect() error {
 
 	for _, smiCrd := range smiCrdList {
 		var smiResourcesMap = map[string][]string{
-			smiCrd + "_table.tsv":    []string{"get", smiCrd, "--all-namespaces", "-o=wide"},
+			smiCrd + "_list.tsv":     []string{"get", smiCrd, "--all-namespaces", "-o=wide"},
 			smiCrd + "_configs.json": []string{"get", smiCrd, "--all-namespaces", "-o=json"},
 		}
 

--- a/pkg/utils/helper.go
+++ b/pkg/utils/helper.go
@@ -127,18 +127,22 @@ func GetUrlWithRetries(url string, maxRetries int) ([]byte, error) {
 		if err == nil {
 			break
 		}
-		log.Printf("Error curling %s: %+v. %d retries remaining...\n", url, err, maxRetries-i)
+		log.Printf("Error with HTTP GET %s: %+v. %d retries remaining...\n", url, err, maxRetries-i)
 		time.Sleep(5 * time.Second)
 	}
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("HTTP GET request succeeded for url %s", url)
 	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
 }
 
 // WriteToFile writes data to a file
 func WriteToFile(fileName string, data string) error {
+	if err := os.MkdirAll(filepath.Dir(fileName), os.ModePerm); err != nil {
+		return fmt.Errorf("Fail to create path directories for file %s: %+v", fileName, err)
+	}
 	f, err := os.Create(fileName)
 	defer f.Close()
 	if err != nil {


### PR DESCRIPTION
This refactor does the following:
* Extracts ground truth collection into a function and makes it mesh specific
* Reorders code for cleanliness
* Organizes files into subdirectories as defined by the rootPath at the beginning of each function. New directory structure roughly looks like (red ending lines indicate file):
![image](https://user-images.githubusercontent.com/42152676/118735344-3b5dfb80-b80e-11eb-8136-db3a63ee4f8f.png)
* Renames functions to add context/parallelize nomenclature
* Improves error handling
