### PR TITLE
ref: rename osmlogs and smilogs collectors to osm and smi

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -41,10 +41,10 @@ func main() {
 	collectors = append(collectors, kubeletCmdCollector)
 	systemPerfCollector := collector.NewSystemPerfCollector(exporter)
 	collectors = append(collectors, systemPerfCollector)
-	osmLogsCollector := collector.NewOsmLogsCollector(exporter)
-	collectors = append(collectors, osmLogsCollector)
-	smiLogsCollector := collector.NewSmiLogsCollector(exporter)
-	collectors = append(collectors, smiLogsCollector)
+	osmCollector := collector.NewOsmCollector(exporter)
+	collectors = append(collectors, osmCollector)
+	smiCollector := collector.NewSmiCollector(exporter)
+	collectors = append(collectors, smiCollector)
 
 	for _, c := range collectors {
 		waitgroup.Add(1)

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -25,10 +25,10 @@ const (
 	NetworkOutbound
 	// NodeLogs defines NodeLogs Collector Type
 	NodeLogs
-	// OsmLogs defines OsmLogs Collector Type
-	OsmLogs
-	// SmiLogs defines SmiLogs Collector Type
-	SmiLogs
+	// Osm defines Osm Collector Type
+	Osm
+	// Smi defines Smi Collector Type
+	Smi
 	// SystemLogs defines SystemLogs Collector Type
 	SystemLogs
 	// SystemPerf defines SystemPerf Collector Type
@@ -37,7 +37,7 @@ const (
 
 // Name returns type name
 func (t Type) name() string {
-	return [...]string{"dns", "containerlogs", "iptables", "kubeletcmd", "kubeobjects", "networkoutbound", "nodelogs", "osmlogs", "smilogs", "systemlogs", "systemperf"}[t]
+	return [...]string{"dns", "containerlogs", "iptables", "kubeletcmd", "kubeobjects", "networkoutbound", "nodelogs", "osm", "smi", "systemlogs", "systemperf"}[t]
 }
 
 // BaseCollector defines Base Collector

--- a/pkg/collector/smi_collector.go
+++ b/pkg/collector/smi_collector.go
@@ -9,25 +9,25 @@ import (
 	"github.com/Azure/aks-periscope/pkg/utils"
 )
 
-// SmiLogsCollector defines an SmiLogs Collector struct
-type SmiLogsCollector struct {
+// SmiCollector defines an Smi Collector struct
+type SmiCollector struct {
 	BaseCollector
 }
 
-var _ interfaces.Collector = &SmiLogsCollector{}
+var _ interfaces.Collector = &SmiCollector{}
 
-// NewSmiLogsCollector is a constructor
-func NewSmiLogsCollector(exporter interfaces.Exporter) *SmiLogsCollector {
-	return &SmiLogsCollector{
+// NewSmiCollector is a constructor
+func NewSmiCollector(exporter interfaces.Exporter) *SmiCollector {
+	return &SmiCollector{
 		BaseCollector: BaseCollector{
-			collectorType: SmiLogs,
+			collectorType: Smi,
 			exporter:      exporter,
 		},
 	}
 }
 
 // Collect implements the interface method
-func (collector *SmiLogsCollector) Collect() error {
+func (collector *SmiCollector) Collect() error {
 	smiCrdList, err := getSmiCustomResourceDefinitions()
 	if err != nil {
 		return err


### PR DESCRIPTION
Renaming collectors to drop "logs" because these collectors do a lot more than collect logs