### PR TITLE
add a check if OSM flag is enabled then don't do anything for SMI flag

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -45,13 +45,14 @@ func main() {
 
 	// Checks flags and adds specified collector if matched
 	flags := strings.Fields(os.Getenv("FLAGS_LIST"))
+	isOsmEnabled := false
 	for _, flag := range flags {
-		switch flag {
-		case "OSM":
+		if flag == "OSM" {
+			isOsmEnabled = true
 			osmCollector := collector.NewOsmCollector(exporter)
 			smiCollector := collector.NewSmiCollector(exporter)
 			collectors = append(collectors, osmCollector, smiCollector)
-		case "SMI":
+		} else if flag == "SMI" && !isOsmEnabled {
 			smiCollector := collector.NewSmiCollector(exporter)
 			collectors = append(collectors, smiCollector)
 		}


### PR DESCRIPTION
If a user enables both `OSM` and `SMI` in the `FLAGS_LIST` then we should only enable the SMI collector once.