### PR TITLE
fix: fix error handling for osm without monitored ns

### DIFF
--- a/pkg/collector/osm_collector.go
+++ b/pkg/collector/osm_collector.go
@@ -42,14 +42,14 @@ func (collector *OsmCollector) Collect() error {
 
 	for _, meshName := range meshList {
 		meshRootPath := filepath.Join(rootPath, "mesh_"+meshName)
+
 		monitoredNamespaces, err := utils.GetResourceList([]string{"get", "namespaces", "--all-namespaces", "-l", "openservicemesh.io/monitored-by=" + meshName, "-o", "jsonpath={..name}"}, " ")
 		if err != nil {
-			log.Printf("Failed to get namespaces within osm mesh '%s': %+v\n", meshName, err)
-			continue
+			log.Printf("Failed to find any namespaces monitored by OSM named '%s': %+v\n", meshName, err)
 		}
 		controllerNamespaces, err := utils.GetResourceList([]string{"get", "deployments", "--all-namespaces", "-l", "app=osm-controller,meshName=" + meshName, "-o", "jsonpath={..metadata.namespace}"}, " ")
 		if err != nil {
-			return err
+			log.Printf("Failed to find controller namespace(s) for OSM named '%s': %+v\n", meshName, err)
 		}
 		callNamespaceCollectors(collector, monitoredNamespaces, controllerNamespaces, meshRootPath, meshName)
 		collectGroundTruth(collector, meshRootPath, meshName)


### PR DESCRIPTION
Removes returns/loop contuances if no monitored/controller namaspaces are found

Prev:
- If no monitored ns found, would go to next mesh in range
- Return if no controller ns found

Now:
- If no monitored ns found, still look for controller ns
- If no controller ns found, still try to collect info for monitored ns
- If either of them are empty, that element's loop in callNamespaceCollectors won't have anything to iterate over so won't cause any errors