### PR TITLE
Add logic to make OSM and SMI flags mutually exclusive

### DIFF
--- a/cmd/aks-periscope/aks-periscope.go
+++ b/cmd/aks-periscope/aks-periscope.go
@@ -61,11 +61,11 @@ func main() {
 		collectors = append(collectors, systemPerfCollector)
 	}
 
+	// OSM and SMI flags are mutually exclusive
 	if contains(collectorList, "OSM") {
 		collectors = append(collectors, osmCollector)
-	}
-
-	if contains(collectorList, "SMI") {
+		collectors = append(collectors, smiCollector)
+	} else if contains(collectorList, "SMI") {
 		collectors = append(collectors, smiCollector)
 	}
 


### PR DESCRIPTION
If OSM flag is enabled then don't need to check for SMI flag, as it enables both OSM and SMI collectors.